### PR TITLE
fix: header was unreadable due to the elements below

### DIFF
--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -68,7 +68,7 @@ export default function Navigation({
 
   return (
     <>
-      <header className="fixed top-0 left-0 right-0 z-50 glass">
+      <header className="fixed top-0 left-0 right-0 z-50 glass backdrop-blur-md">
         <div className="absolute inset-0 bg-gradient-to-r from-purple-900/10 via-transparent to-blue-900/10"></div>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">


### PR DESCRIPTION
Исправлен внешний вид хедера, теперь к нему накинут блюр и он остаётся разборчивым при наложении на элементы ниже.

До:

![image](https://github.com/user-attachments/assets/f9c632bc-743e-4964-8276-d1e0a4a361bd)

После:

![image](https://github.com/user-attachments/assets/b4a85a78-7732-44ee-8206-42009a92012b)
